### PR TITLE
Feature/#16 schedule navigation

### DIFF
--- a/app/src/main/kotlin/com/ddd/oi/OiApp.kt
+++ b/app/src/main/kotlin/com/ddd/oi/OiApp.kt
@@ -6,15 +6,12 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideIn
 import androidx.compose.animation.slideOut
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -36,6 +33,7 @@ import com.ddd.oi.presentation.core.designsystem.component.MainBottomBar
 import com.ddd.oi.presentation.core.designsystem.theme.OiTheme
 import com.ddd.oi.presentation.core.designsystem.util.Dimens
 import com.ddd.oi.presentation.core.navigation.OiNavigator
+import com.ddd.oi.presentation.core.navigation.Route
 import kotlinx.coroutines.launch
 
 @Composable
@@ -70,7 +68,7 @@ fun OiApp(
                 exit = fadeOut() + slideOut { IntOffset(0, it.height) }
             ) {
                 FloatingActionButton(
-                    onClick = navigator::navigateToUpsertSchedule,
+                    onClick = { navigator.navigateToUpsertSchedule(null, Route.UpsertSchedule())},
                     shape = CircleShape,
                     containerColor = OiTheme.colors.iconBrand,
                     elevation = FloatingActionButtonDefaults.elevation(0.dp),

--- a/app/src/main/kotlin/com/ddd/oi/navigation/OiNavHost.kt
+++ b/app/src/main/kotlin/com/ddd/oi/navigation/OiNavHost.kt
@@ -1,7 +1,6 @@
 package com.ddd.oi.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import com.ddd.oi.presentation.core.navigation.OiNavigator
@@ -44,5 +43,4 @@ fun OiNavHost(
         )
         scheduleDetailNavGraph()
     }
-
 }

--- a/app/src/main/kotlin/com/ddd/oi/navigation/OiNavHost.kt
+++ b/app/src/main/kotlin/com/ddd/oi/navigation/OiNavHost.kt
@@ -27,11 +27,14 @@ fun OiNavHost(
         homeNavGraph()
 
         scheduleNavGraph(
-            navigateToCreateSchedule = { navigator.navigateToUpsertSchedule() },
+            navigateToCreateSchedule = { schedule, scheduleCopy ->
+                navigator.navigateToUpsertSchedule(schedule, scheduleCopy)
+            },
             onShowSnackbar = onShowSnackbar
         )
 
         upsertScheduleNavGraph(
+            navigator = navigator,
             navigatePopBack = { scheduleCreated ->
                 navigator.navController.previousBackStackEntry
                     ?.savedStateHandle

--- a/data/src/main/kotlin/com/ddd/oi/data/schedule/model/ScheduleRequest.kt
+++ b/data/src/main/kotlin/com/ddd/oi/data/schedule/model/ScheduleRequest.kt
@@ -10,5 +10,5 @@ data class ScheduleRequest(
     val endDate: String,
     @SerialName("mobility") val mobility: TransportationDto,
     @SerialName("scheduleTag") val scheduleTag: CategoryDto,
-    val groupList: List<GroupDto>
+    @SerialName("groups") val groupList: List<GroupDto>
 )

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/core/designsystem/component/oidaterangebottomsheet/OiDateRangeBottomSheet.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/core/designsystem/component/oidaterangebottomsheet/OiDateRangeBottomSheet.kt
@@ -114,7 +114,7 @@ fun OiDateRangeBottomSheet(
                 enabled = uiState.isButtonEnabled,
                 onClick = {
                     val startDate = uiState.selectedStartDate ?: return@OiButton
-                    val endDate = uiState.selectedEndDate ?: return@OiButton
+                    val endDate = uiState.selectedEndDate ?: startDate
                     val startLong = startDate.atStartOfDayIn(TimeZone.currentSystemDefault()).toEpochMilliseconds()
                     val endLong = endDate.atStartOfDayIn(TimeZone.currentSystemDefault()).toEpochMilliseconds()
                     onUpsertScheduleClick(startLong, endLong, uiState.hasSchedulesInSelectedRange)

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/core/designsystem/component/oidaterangebottomsheet/contract/DateRangeBottomSheetContract.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/core/designsystem/component/oidaterangebottomsheet/contract/DateRangeBottomSheetContract.kt
@@ -66,7 +66,6 @@ data class DateRangeBottomSheetState(
     val isButtonEnabled: Boolean
         get() {
             val startDate = selectedStartDate ?: return false
-            val endDate = selectedEndDate ?: return false
             return !isLoading && !hasScheduleLimitExceeded
         }
 

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/core/navigation/OiNavigator.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/core/navigation/OiNavigator.kt
@@ -23,6 +23,9 @@ import kotlinx.collections.immutable.toPersistentList
 class OiNavigator(
     val navController: NavHostController
 ) {
+    /**
+     * TODO: local 일정의 id 값으로 받아오는 방향으로 리팩터링
+     */
     private var tempScheduleData: ScheduleNavData? = null
 
     private val previousDestination = mutableStateOf<NavDestination?>(null)

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/core/navigation/OiNavigator.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/core/navigation/OiNavigator.kt
@@ -13,6 +13,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.ddd.oi.presentation.upsertschedule.navigateToInsertSchedule
 import com.ddd.oi.presentation.home.navigateToHome
+import com.ddd.oi.presentation.schedule.model.ScheduleNavData
 import com.ddd.oi.presentation.schedule.navigateToSchedule
 import com.ddd.oi.presentation.scheduledetail.navigateToScheduleDetail
 import kotlinx.collections.immutable.PersistentList
@@ -22,6 +23,8 @@ import kotlinx.collections.immutable.toPersistentList
 class OiNavigator(
     val navController: NavHostController
 ) {
+    private var tempScheduleData: ScheduleNavData? = null
+
     private val previousDestination = mutableStateOf<NavDestination?>(null)
 
     private val currentDestination: NavDestination?
@@ -63,10 +66,24 @@ class OiNavigator(
             MainTab.SCHEDULE -> navController.navigateToSchedule(navOptions)
         }
     }
-    fun navigateToUpsertSchedule() = navController.navigateToInsertSchedule()
+
+    fun navigateToUpsertSchedule(
+        schedule: ScheduleNavData?,
+        scheduleCopyState: Route.UpsertSchedule
+    ) {
+        tempScheduleData = schedule
+        navController.navigateToInsertSchedule(scheduleCopyState)
+    }
+
     fun navigateToScheduleDetail() = navController.navigateToScheduleDetail()
     fun popBackStack() {
         navController.popBackStack()
+    }
+
+    fun consumeTempSchedule(): ScheduleNavData? {
+        return tempScheduleData.also {
+            tempScheduleData = null
+        }
     }
 }
 

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/core/navigation/RouteModel.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/core/navigation/RouteModel.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 sealed interface Route {
     @Serializable
-    data object UpsertSchedule: Route
+    data class UpsertSchedule(val mode: UpsertMode = UpsertMode.CREATE): Route
 
     @Serializable
     data object ScheduleDetail: Route
@@ -16,4 +16,12 @@ sealed interface MainTabRoute : Route {
 
     @Serializable
     data object Schedule: MainTabRoute
+}
+
+
+@Serializable
+enum class UpsertMode {
+    CREATE,
+    EDIT,
+    COPY
 }

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/schedule/ScheduleNavGraph.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/schedule/ScheduleNavGraph.kt
@@ -5,13 +5,15 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.ddd.oi.presentation.core.navigation.MainTabRoute
+import com.ddd.oi.presentation.core.navigation.Route
+import com.ddd.oi.presentation.schedule.model.ScheduleNavData
 
 fun NavController.navigateToSchedule(navOptions: NavOptions) {
     navigate(MainTabRoute.Schedule, navOptions)
 }
 
 fun NavGraphBuilder.scheduleNavGraph(
-    navigateToCreateSchedule: () -> Unit,
+    navigateToCreateSchedule: (ScheduleNavData?, Route.UpsertSchedule) -> Unit,
     onShowSnackbar: (String) -> Unit
 ) {
     composable<MainTabRoute.Schedule> { backStackEntry ->

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/schedule/model/ScheduleNavData.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/schedule/model/ScheduleNavData.kt
@@ -1,0 +1,19 @@
+package com.ddd.oi.presentation.schedule.model
+
+import com.ddd.oi.domain.model.schedule.Category
+import com.ddd.oi.domain.model.schedule.Party
+import com.ddd.oi.domain.model.schedule.Place
+import com.ddd.oi.domain.model.schedule.Transportation
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ScheduleNavData(
+    val id: Long? = null,
+    val title: String? = null,
+    val category: Category? = null,
+    val startedAt: Long? = null,
+    val endedAt: Long? = null,
+    val transportation: Transportation? = null,
+    val party: Set<Party>? = null,
+    val placeList: List<Place>? = null
+)

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/schedule/model/ScheduleNavDataFactory.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/schedule/model/ScheduleNavDataFactory.kt
@@ -1,0 +1,36 @@
+package com.ddd.oi.presentation.schedule.model
+
+import com.ddd.oi.domain.model.schedule.Schedule
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+
+object ScheduleNavDataFactory {
+    fun createLocalDateCreate(localDate: LocalDate): ScheduleNavData {
+        val date = localDate.atStartOfDayIn(TimeZone.currentSystemDefault()).toEpochMilliseconds()
+        return ScheduleNavData(startedAt = date)
+    }
+
+    fun createForCopy(original: Schedule): ScheduleNavData {
+        return ScheduleNavData(
+            title = original.title,
+            category = original.category,
+            transportation = original.transportation,
+            party = original.partySet,
+            placeList = original.placeList
+        )
+    }
+
+    fun createForEdit(original: Schedule): ScheduleNavData {
+        return ScheduleNavData(
+            id = original.id,
+            title = original.title,
+            category = original.category,
+            startedAt = original.startedAt.atStartOfDayIn(TimeZone.currentSystemDefault()).toEpochMilliseconds(),
+            endedAt = original.endedAt.atStartOfDayIn(TimeZone.currentSystemDefault()).toEpochMilliseconds(),
+            transportation = original.transportation,
+            party = original.partySet,
+            placeList = original.placeList
+        )
+    }
+}

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/upsertschedule/UpsertScheduleNavGraph.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/upsertschedule/UpsertScheduleNavGraph.kt
@@ -3,18 +3,22 @@ package com.ddd.oi.presentation.upsertschedule
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.ddd.oi.presentation.core.navigation.OiNavigator
 import com.ddd.oi.presentation.core.navigation.Route
 
-fun NavController.navigateToInsertSchedule() {
-    navigate(Route.UpsertSchedule)
+fun NavController.navigateToInsertSchedule(scheduleCopy: Route.UpsertSchedule) {
+    navigate(scheduleCopy)
 }
 
 fun NavGraphBuilder.upsertScheduleNavGraph(
+    navigator: OiNavigator,
     navigatePopBack: (Boolean) -> Unit
 ) {
     composable<Route.UpsertSchedule> {
+        val scheduleNavData = navigator.consumeTempSchedule()
         UpsertScheduleScreen(
-            navigatePopBack = navigatePopBack
+            navigatePopBack = navigatePopBack,
+            scheduleNavData = scheduleNavData
         )
     }
 }

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/upsertschedule/UpsertScheduleScreen.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/upsertschedule/UpsertScheduleScreen.kt
@@ -7,10 +7,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -81,7 +81,7 @@ fun UpsertScheduleScreen(
     val isButtonEnabled = uiState.isButtonEnable
 
     var showDateRangeBottomSheet by remember { mutableStateOf(false) }
-    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var isPastModalVisible by remember { mutableStateOf(false) }
     var isAlreadyScheduledModalVisible by remember { mutableStateOf(false) }
     var hasInRangeSchedule by remember { mutableStateOf(false) }
@@ -138,7 +138,7 @@ fun UpsertScheduleScreen(
         ) {
             Box(
                 modifier = Modifier
-                    .wrapContentHeight()
+                    .fillMaxHeight(0.7f)
                     .background(white)
             ) {
                 OiDateRangeBottomSheet { start, end, hasSchedules ->

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/upsertschedule/UpsertScheduleScreen.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/upsertschedule/UpsertScheduleScreen.kt
@@ -7,10 +7,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -33,7 +33,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ddd.oi.domain.model.schedule.Category
 import com.ddd.oi.domain.model.schedule.Party
-import com.ddd.oi.domain.model.schedule.Schedule
 import com.ddd.oi.domain.model.schedule.Transportation
 import com.ddd.oi.presentation.R
 import com.ddd.oi.presentation.core.designsystem.component.common.OiButton
@@ -49,6 +48,7 @@ import com.ddd.oi.presentation.core.designsystem.component.dialog.OiAlreadySched
 import com.ddd.oi.presentation.core.designsystem.component.oidaterangebottomsheet.OiDateRangeBottomSheet
 import com.ddd.oi.presentation.core.designsystem.theme.OiTheme
 import com.ddd.oi.presentation.core.designsystem.theme.white
+import com.ddd.oi.presentation.schedule.model.ScheduleNavData
 import com.ddd.oi.presentation.upsertschedule.contract.UpsertScheduleSideEffect
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -57,12 +57,12 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 @Composable
 fun UpsertScheduleScreen(
     modifier: Modifier = Modifier,
-    schedule: Schedule? = null,
+    scheduleNavData: ScheduleNavData? = null,
     navigatePopBack: (scheduleCreated: Boolean) -> Unit = {},
     viewModel: UpsertScheduleViewModel = hiltViewModel()
 ) {
     LaunchedEffect(Unit) {
-        schedule?.let(viewModel::setSchedule)
+        scheduleNavData?.let(viewModel::setSchedule)
     }
 
     viewModel.collectSideEffect { sideEffect ->
@@ -81,7 +81,7 @@ fun UpsertScheduleScreen(
     val isButtonEnabled = uiState.isButtonEnable
 
     var showDateRangeBottomSheet by remember { mutableStateOf(false) }
-    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
     var isPastModalVisible by remember { mutableStateOf(false) }
     var isAlreadyScheduledModalVisible by remember { mutableStateOf(false) }
     var hasInRangeSchedule by remember { mutableStateOf(false) }
@@ -138,7 +138,7 @@ fun UpsertScheduleScreen(
         ) {
             Box(
                 modifier = Modifier
-                    .fillMaxHeight(0.6f)
+                    .wrapContentHeight()
                     .background(white)
             ) {
                 OiDateRangeBottomSheet { start, end, hasSchedules ->

--- a/presentation/src/main/kotlin/com/ddd/oi/presentation/upsertschedule/contract/UpsertScheduleState.kt
+++ b/presentation/src/main/kotlin/com/ddd/oi/presentation/upsertschedule/contract/UpsertScheduleState.kt
@@ -3,6 +3,7 @@ package com.ddd.oi.presentation.upsertschedule.contract
 import androidx.compose.runtime.Stable
 import com.ddd.oi.domain.model.schedule.Category
 import com.ddd.oi.domain.model.schedule.Party
+import com.ddd.oi.domain.model.schedule.Place
 import com.ddd.oi.domain.model.schedule.Transportation
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
@@ -11,13 +12,14 @@ import kotlinx.datetime.todayIn
 
 @Stable
 data class UpsertScheduleState(
-    val id: Int,
+    val id: Long,
     val title: String,
     val category: Category?,
     val startDate: Long,
     val endDate: Long,
     val transportation: Transportation?,
     val party: Set<Party>,
+    val placeList: List<Place>
 ) {
 
     companion object {
@@ -28,7 +30,8 @@ data class UpsertScheduleState(
             startDate = System.currentTimeMillis(),
             endDate = -1L,
             transportation = null,
-            party = emptySet()
+            party = emptySet(),
+            placeList = emptyList()
         )
     }
 


### PR DESCRIPTION
## **✏️ Work Description**
- 일정 -> 일정 생성간 데이터 전달 작업입니다.

## 🔨 변경 사항

- [ ]  새로운 기능 추가

## **📢 To Reviewers**
네비게이션 간 데이터 전달에서 `Schedule` 에서 Set, List 때문에 전달을 할 수 없어 여러 방법을 고민했습니다.
- `schedule`을 CustomNavTpye으로 사용 시(place가 많아지면 길이가 길어지면 url 길이제한 및 안정성x)
- Set, List를 String으로 변환해서 기본타입으로 만들고 upsert에서 받을 때 다시 Set, List화 시킨다
- 액티비티 스코프에서 전달할 일정의 데이터를 가지고 있는 공유 뷰모델을 생성한다
- OiNavigator에 값을 저장하고 꺼내서 사용한다

현재는 OiNavigator에 
```kotlin
private var tempScheduleData: ScheduleNavData? = null
```
으로 설정하고 
```kotlin
fun NavGraphBuilder.upsertScheduleNavGraph(
    navigator: OiNavigator,
    navigatePopBack: (Boolean) -> Unit
) {
    composable<Route.UpsertSchedule> {
        val scheduleNavData = navigator.consumeTempSchedule()
        UpsertScheduleScreen(
            navigatePopBack = navigatePopBack,
            scheduleNavData = scheduleNavData
        )
    }
}
```
NavGraphBuilder.upsertScheduleNavGraph에 navigator를 전달하게 되었는데
동작하는데 문제는 없지만 책임과 관심사 분리가 명확히 되지 않는 문제가 있습니다.

[공식문서 ](https://developer.android.com/guide/navigation/use-graph/pass-data?hl=ko&_gl=1*1uxo2gy*_up*MQ..*_ga*ODY4MjM3MjIuMTc1MDgyMjYwMA..*_ga_6HH9YJMN9M*czE3NTA4MjI2MDAkbzEkZzAkdDE3NTA4MjI2MDAkajYwJGwwJGgzMjYxOTQwMzY.#Safe-args) 에서는 대상 간 이동할 때 최소한의 데이터(예: id)만 전달하고 대량의 데이터일 경우 `viewModel`을 권장하고 있기는 합니다.

일정 수정과 복사가 있어 어쨋든 모든 일정 데이터를 전달해야할 것 같은데 공유 뷰모델을 사용할지, 지금과 같은 방법을 사용할지, 더 좋은 방법이 있다면 의견을 듣고싶습니다.

## 📎 **Related issue**
- Relevant #16
